### PR TITLE
Add a check for an empty message body

### DIFF
--- a/send_sns.py
+++ b/send_sns.py
@@ -99,5 +99,10 @@ if __name__ == "__main__":
     #message is piped in
     for line in sys.stdin.readlines():
         msg = msg + "\n" + line
+        
+    #sns will throw a bad argument error for an empty body but is happy with a blank line
+    if msg == "":
+        msg = "\n"
+
     
     send_sns(tornado.options.options.topic, msg, tornado.options.options.sub)


### PR DESCRIPTION
SNS will throw a bad argument error if the body of a notification is empty. Just a blank line is enough to keep it happy. This change changes a blank body to a single blank line.

This is useful for SMS notifications, where SNS only delivers the subject as the SMS, so the body of the message has no purpose and can be blank.
